### PR TITLE
fix: duration

### DIFF
--- a/Lifx/Communication/Requests/Payloads/SetColorRequestPayload.cs
+++ b/Lifx/Communication/Requests/Payloads/SetColorRequestPayload.cs
@@ -5,7 +5,9 @@ internal sealed record SetColorRequestPayload(
 	Color Color,
 	Percentage Brightness,
 	Temperature Temperature,
-	uint DurationInMilliseconds
+	// ReSharper disable once BuiltInTypeReferenceStyle
+	// Required to be UInt32 per protocol docs, type uint is not honored
+	UInt32 DurationInMilliseconds
 ) : RequestPayload
 {
 	public override byte[] GetData()

--- a/Lifx/Communication/Requests/Payloads/SetPowerRequestPayload.cs
+++ b/Lifx/Communication/Requests/Payloads/SetPowerRequestPayload.cs
@@ -3,7 +3,9 @@
 // Contains information used to set a light's power over a duration in milliseconds.
 internal sealed record SetPowerRequestPayload(
 	Power Power,
-	uint DurationInMilliseconds
+	// ReSharper disable once BuiltInTypeReferenceStyle
+	// Protocol Specifies UInt32, normal uint will not work
+	UInt32 DurationInMilliseconds
 ) : RequestPayload
 {
 	public override byte[] GetData()


### PR DESCRIPTION
closes #3 
Protocol docs say it must be a UInt32 even though a uint is the same its not treated the same by the bulb so it is not honored.
Tested vs my local lights works like expected and like other DotNet Packages.